### PR TITLE
Fix: Correction des avertissements de sécurité Supabase

### DIFF
--- a/supabase/migrations/20250926182754_fix_search_path_security_warnings.sql
+++ b/supabase/migrations/20250926182754_fix_search_path_security_warnings.sql
@@ -1,0 +1,26 @@
+-- Fix search_path security warnings for all functions
+-- Setting search_path to an empty string prevents malicious search_path manipulation
+
+-- Fix sync_user_to_auth function (trigger function)
+ALTER FUNCTION public.sync_user_to_auth()
+SET search_path = '';
+
+-- Fix get_total_followup_count function (with parameter)
+ALTER FUNCTION public.get_total_followup_count(p_tracked_email_id uuid)
+SET search_path = '';
+
+-- Fix handle_user_updated function (trigger function)
+ALTER FUNCTION public.handle_user_updated()
+SET search_path = '';
+
+-- Fix sync_all_users_from_auth function
+ALTER FUNCTION public.sync_all_users_from_auth()
+SET search_path = '';
+
+-- Fix reschedule_pending_followups function (with parameters)
+ALTER FUNCTION public.reschedule_pending_followups(p_tracked_email_id uuid, p_base_time timestamp with time zone, p_adjustment_hours integer)
+SET search_path = '';
+
+-- Fix handle_new_user function (trigger function)
+ALTER FUNCTION public.handle_new_user()
+SET search_path = '';


### PR DESCRIPTION
## Résumé
- Corrige 6 avertissements de sécurité de type "Function Search Path Mutable" 
- Sécurise toutes les fonctions PostgreSQL contre les manipulations malveillantes du search_path
- La base de données affiche maintenant "No warnings detected" ✅

## Changements
Ajout du paramètre `search_path = ''` pour les fonctions suivantes:
- `sync_user_to_auth`
- `get_total_followup_count`
- `handle_user_updated`
- `sync_all_users_from_auth`
- `reschedule_pending_followups`
- `handle_new_user`

## Test
- Migration appliquée avec succès via `supabase db reset`
- Vérification sur http://127.0.0.1:54323/project/default/advisors/security confirme que tous les avertissements sont résolus

🤖 Generated with Claude Code (https://claude.ai/code)