### PR TITLE
Fix: Activation de RLS sur les tables système critiques

### DIFF
--- a/supabase/migrations/20250926182754_fix_search_path_security_warnings.sql
+++ b/supabase/migrations/20250926182754_fix_search_path_security_warnings.sql
@@ -1,0 +1,26 @@
+-- Fix search_path security warnings for all functions
+-- Setting search_path to an empty string prevents malicious search_path manipulation
+
+-- Fix sync_user_to_auth function (trigger function)
+ALTER FUNCTION public.sync_user_to_auth()
+SET search_path = '';
+
+-- Fix get_total_followup_count function (with parameter)
+ALTER FUNCTION public.get_total_followup_count(p_tracked_email_id uuid)
+SET search_path = '';
+
+-- Fix handle_user_updated function (trigger function)
+ALTER FUNCTION public.handle_user_updated()
+SET search_path = '';
+
+-- Fix sync_all_users_from_auth function
+ALTER FUNCTION public.sync_all_users_from_auth()
+SET search_path = '';
+
+-- Fix reschedule_pending_followups function (with parameters)
+ALTER FUNCTION public.reschedule_pending_followups(p_tracked_email_id uuid, p_base_time timestamp with time zone, p_adjustment_hours integer)
+SET search_path = '';
+
+-- Fix handle_new_user function (trigger function)
+ALTER FUNCTION public.handle_new_user()
+SET search_path = '';

--- a/supabase/migrations/20250926183736_enable_rls_system_tables.sql
+++ b/supabase/migrations/20250926183736_enable_rls_system_tables.sql
@@ -1,0 +1,85 @@
+-- Enable Row Level Security on system tables
+-- These tables are technical/system tables that should only be accessed by Edge Functions
+-- No direct frontend user access is required
+
+-- =============================================
+-- ENABLE RLS ON SYSTEM TABLES
+-- =============================================
+
+-- Enable RLS on webhook subscriptions table
+ALTER TABLE webhook_subscriptions ENABLE ROW LEVEL SECURITY;
+
+-- Enable RLS on message headers table
+ALTER TABLE message_headers ENABLE ROW LEVEL SECURITY;
+
+-- Enable RLS on detection logs table
+ALTER TABLE detection_logs ENABLE ROW LEVEL SECURITY;
+
+-- =============================================
+-- RLS POLICIES FOR WEBHOOK_SUBSCRIPTIONS
+-- =============================================
+
+-- Service role (Edge Functions) has full access
+CREATE POLICY "Service role full access"
+  ON webhook_subscriptions
+  FOR ALL
+  TO service_role
+  USING (true);
+
+-- Admins can read for debugging purposes only
+CREATE POLICY "Admins read only for debugging"
+  ON webhook_subscriptions
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM users
+      WHERE id = auth.uid()
+      AND role = 'administrateur'
+    )
+  );
+
+-- =============================================
+-- RLS POLICIES FOR MESSAGE_HEADERS
+-- =============================================
+
+-- Service role (Edge Functions) has full access
+CREATE POLICY "Service role full access"
+  ON message_headers
+  FOR ALL
+  TO service_role
+  USING (true);
+
+-- Admins can read for debugging purposes only
+CREATE POLICY "Admins read only for debugging"
+  ON message_headers
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM users
+      WHERE id = auth.uid()
+      AND role = 'administrateur'
+    )
+  );
+
+-- =============================================
+-- RLS POLICIES FOR DETECTION_LOGS
+-- =============================================
+
+-- Service role (Edge Functions) has full access
+CREATE POLICY "Service role full access"
+  ON detection_logs
+  FOR ALL
+  TO service_role
+  USING (true);
+
+-- Admins can read for debugging purposes only
+CREATE POLICY "Admins read only for debugging"
+  ON detection_logs
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM users
+      WHERE id = auth.uid()
+      AND role = 'administrateur'
+    )
+  );


### PR DESCRIPTION
## 🔐 Résumé
Corrige un **problème de sécurité majeur** en activant Row Level Security (RLS) sur 3 tables système qui étaient accessibles sans restriction.

## 🚨 Problème de sécurité résolu
Les tables suivantes n'avaient pas RLS activé, permettant un accès non contrôlé depuis le frontend :
- `webhook_subscriptions` - Gestion des webhooks Microsoft Graph
- `message_headers` - En-têtes d'emails pour la détection de threading
- `detection_logs` - Journaux techniques de détection de réponses

## ✅ Solution implémentée

### 1. Activation de RLS
```sql
ALTER TABLE webhook_subscriptions ENABLE ROW LEVEL SECURITY;
ALTER TABLE message_headers ENABLE ROW LEVEL SECURITY;
ALTER TABLE detection_logs ENABLE ROW LEVEL SECURITY;
```

### 2. Politiques restrictives
- **Service role** : Accès complet pour les Edge Functions uniquement
- **Administrateurs** : Lecture seule pour debugging
- **Utilisateurs** : Aucun accès (tables purement techniques)

## 🧪 Tests
- ✅ Migration appliquée avec succès (`supabase db reset`)
- ✅ RLS confirmé actif : `rowsecurity = t` sur les 3 tables
- ✅ Politiques créées et fonctionnelles (6 policies au total)
- ✅ Edge Functions conservent leur accès complet via service_role

## 🔒 Impact sécurité
- **Avant** : Tables accessibles sans restriction depuis le frontend
- **Après** : Accès strictement contrôlé et limité aux services autorisés
- **Edge Functions** : Fonctionnement normal préservé
- **Données sensibles** : Protégées des accès non autorisés

🤖 Generated with Claude Code (https://claude.ai/code)