### PR TITLE
feat: Ajout des politiques RLS pour la table email_bounces

### DIFF
--- a/supabase/migrations/20250929144353_enable_rls_email_bounces.sql
+++ b/supabase/migrations/20250929144353_enable_rls_email_bounces.sql
@@ -1,0 +1,51 @@
+-- Enable RLS on email_bounces table
+ALTER TABLE email_bounces ENABLE ROW LEVEL SECURITY;
+
+-- Policy: Allow users to view bounces for emails from their assigned mailboxes
+CREATE POLICY "Users can view bounces for their assigned mailboxes" ON email_bounces
+    FOR SELECT
+    USING (
+        EXISTS (
+            SELECT 1 FROM tracked_emails te
+            JOIN mailboxes m ON te.mailbox_id = m.id
+            JOIN user_mailbox_assignments uma ON m.id = uma.mailbox_id
+            WHERE te.id = email_bounces.tracked_email_id
+            AND uma.user_id = auth.uid()
+        )
+    );
+
+-- Policy: Allow managers and admins to view all bounces
+CREATE POLICY "Managers can view all bounces" ON email_bounces
+    FOR SELECT
+    USING (
+        EXISTS (
+            SELECT 1 FROM users
+            WHERE id = auth.uid()
+            AND role IN ('administrateur', 'manager')
+        )
+    );
+
+-- Policy: Allow service role to insert bounces (for webhook processing)
+CREATE POLICY "Service role can insert bounces" ON email_bounces
+    FOR INSERT
+    WITH CHECK (
+        auth.role() = 'service_role'
+    );
+
+-- Policy: Allow service role to update bounces (for webhook processing)
+CREATE POLICY "Service role can update bounces" ON email_bounces
+    FOR UPDATE
+    USING (
+        auth.role() = 'service_role'
+    );
+
+-- Policy: Allow admins to delete bounces
+CREATE POLICY "Admins can delete bounces" ON email_bounces
+    FOR DELETE
+    USING (
+        EXISTS (
+            SELECT 1 FROM users
+            WHERE id = auth.uid()
+            AND role = 'administrateur'
+        )
+    );


### PR DESCRIPTION
## Summary
- ✅ Activation de Row Level Security (RLS) sur la table `email_bounces`
- 🔐 Ajout de 5 politiques de sécurité pour contrôler l'accès aux données

## Politiques implémentées

### Lecture (SELECT)
- **Utilisateurs standard** : Accès aux bounces des emails de leurs mailboxes assignées uniquement
- **Managers/Administrateurs** : Accès complet en lecture à tous les bounces

### Écriture (INSERT/UPDATE)
- **Service role** : Autorisé pour les Edge Functions (traitement des webhooks)

### Suppression (DELETE)
- **Administrateurs uniquement** : Seuls les admins peuvent supprimer des bounces

## Test plan
- [ ] Vérifier que les utilisateurs ne voient que les bounces de leurs mailboxes assignées
- [ ] Vérifier que les managers/admins voient tous les bounces
- [ ] Vérifier que les Edge Functions peuvent créer/modifier des bounces
- [ ] Vérifier que seuls les admins peuvent supprimer des bounces

🤖 Generated with [Claude Code](https://claude.com/claude-code)