### PR TITLE
Fix: Correction du problème mailbox_not_found dans le processeur d'emails

### DIFF
--- a/supabase/functions/mailbox-email-processor/email-processor.ts
+++ b/supabase/functions/mailbox-email-processor/email-processor.ts
@@ -154,7 +154,7 @@ async function processMailboxEmails_Single(
           const processingResult = await processEmailWithEnhancedDetection(
             supabase,
             email,
-            mailbox.id,
+            mailbox,
             tenantConfig
           )
 

--- a/supabase/functions/mailbox-email-processor/enhanced-processor.ts
+++ b/supabase/functions/mailbox-email-processor/enhanced-processor.ts
@@ -7,6 +7,9 @@ import {
   EdgeSupabaseClient
 } from '../_shared/types.ts'
 import {
+  MailboxRow
+} from './shared-types.ts'
+import {
   analyzeConversationContext,
   shouldCreateNewTrackedEmail,
   enhancedResponseDetection,
@@ -20,7 +23,6 @@ import {
   handleEmailResponse
 } from '../microsoft-webhook/response-detector.ts'
 import {
-  getMailboxByUserId,
   logDetectionAttempt
 } from '../microsoft-webhook/database-manager.ts'
 import {
@@ -136,7 +138,7 @@ function convertToEmailMessage(graphEmail: GraphEmail): {
 export async function processEmailWithEnhancedDetection(
   supabase: EdgeSupabaseClient,
   graphEmail: GraphEmail,
-  mailboxId: string,
+  mailbox: MailboxRow,
   _tenantConfig: unknown
 ): Promise<{
   processed: boolean
@@ -163,16 +165,6 @@ export async function processEmailWithEnhancedDetection(
         processed: false,
         action: 'skipped',
         reason: 'internal_email'
-      }
-    }
-
-    // Récupérer la mailbox pour classification
-    const mailbox = await getMailboxByUserId(supabase, mailboxId)
-    if (!mailbox) {
-      return {
-        processed: false,
-        action: 'error',
-        reason: 'mailbox_not_found'
       }
     }
 


### PR DESCRIPTION
## Summary
Correction du problème critique où tous les emails étaient marqués comme `mailbox_not_found` dans la fonction `mailbox-email-processor`.

## Root Cause
La fonction `processEmailWithEnhancedDetection` recevait `mailbox.id` (UUID) mais tentait de l'utiliser comme `microsoft_user_id` dans `getMailboxByUserId()`, causant l'échec de la recherche de mailbox.

## Solution
- Passé l'objet `MailboxRow` complet directement à la fonction
- Éliminé l'appel inutile à `getMailboxByUserId()` puisque l'objet mailbox est déjà disponible
- Conforme à l'architecture utilisant les permissions Application de Microsoft Graph

## Fichiers modifiés
- `supabase/functions/mailbox-email-processor/enhanced-processor.ts`
- `supabase/functions/mailbox-email-processor/email-processor.ts`

## Test plan
- [x] Validation Deno: `deno check` et `deno lint` réussis
- [x] Test fonctionnel: 44 emails traités avec succès
- [x] Prévention doublons: 0 nouvel email sur re-exécution

🤖 Generated with [Claude Code](https://claude.com/claude-code)