### PR TITLE
feat: Ajout de tooltips pour les destinataires et sujets tronqués

### DIFF
--- a/components/tracked-emails/columns/TrackedEmailsColumns.tsx
+++ b/components/tracked-emails/columns/TrackedEmailsColumns.tsx
@@ -8,6 +8,11 @@
 import { ColumnDef } from "@tanstack/react-table";
 import { AlertTriangleIcon, MailIcon } from "lucide-react";
 import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { TrackedEmailStatusBadge } from "../TrackedEmailStatusBadge";
 import { TrackedEmailActions } from "../TrackedEmailActions";
 import { cn } from "@/lib/utils";
@@ -69,14 +74,39 @@ export function createTrackedEmailsColumns(
       accessorKey: "recipient_emails",
       cell: ({ row }) => {
         const email = row.original;
+        const recipients = formatRecipients(email.recipient_emails);
+        const subject = email.subject;
+
         return (
           <div className="min-w-0">
-            <div className="truncate font-medium">
-              {formatRecipients(email.recipient_emails)}
-            </div>
-            <div className="text-muted-foreground truncate text-sm">
-              {email.subject}
-            </div>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <div className="cursor-help truncate font-medium">
+                  {recipients}
+                </div>
+              </TooltipTrigger>
+              <TooltipContent
+                side="top"
+                className="max-w-md break-words"
+                sideOffset={5}
+              >
+                {recipients}
+              </TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <div className="text-muted-foreground cursor-help truncate text-sm">
+                  {subject}
+                </div>
+              </TooltipTrigger>
+              <TooltipContent
+                side="bottom"
+                className="max-w-md break-words"
+                sideOffset={5}
+              >
+                {subject}
+              </TooltipContent>
+            </Tooltip>
           </div>
         );
       },


### PR DESCRIPTION
## Résumé

Ajout de tooltips interactifs pour améliorer la lisibilité de la colonne "Destinataire" lorsque le contenu est tronqué.

## Problème résolu

La colonne "Destinataire" peut avoir un contenu très long si :
- Plusieurs destinataires sont listés
- Le sujet de l'email est long

Le texte était tronqué sans moyen de voir le contenu complet.

## Solution implémentée

### Tooltips ajoutés
- **Destinataires** : Tooltip au-dessus (position: top) affichant la liste complète
- **Sujet** : Tooltip en-dessous (position: bottom) affichant le sujet complet

### Détails techniques
- Import du composant `Tooltip` de Radix UI via `@/components/ui/tooltip`
- Curseur `cursor-help` pour indiquer l'interactivité
- Largeur maximale : `max-w-md` avec `break-words` pour le wrapping
- Offset de 5px pour un meilleur espacement

## Captures d'écran

Les tooltips s'affichent au survol des textes tronqués dans la colonne Destinataire.

## Fichiers modifiés

- `components/tracked-emails/columns/TrackedEmailsColumns.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)