### PR TITLE
feat: Tooltips conditionnels pour textes tronqués dans tableau des emails

### DIFF
--- a/components/tracked-emails/TruncatedTextWithTooltip.tsx
+++ b/components/tracked-emails/TruncatedTextWithTooltip.tsx
@@ -1,0 +1,78 @@
+/**
+ * TruncatedTextWithTooltip Component
+ *
+ * Displays text with an optional tooltip that only appears when the text is truncated.
+ * Uses a ref to detect if the content overflows its container.
+ */
+
+"use client";
+
+import { useRef, useState, useEffect } from "react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+
+interface TruncatedTextWithTooltipProps {
+  text: string;
+  className?: string;
+  tooltipSide?: "top" | "bottom" | "left" | "right";
+  tooltipClassName?: string;
+}
+
+/**
+ * Component that shows a tooltip only when text is truncated
+ */
+export function TruncatedTextWithTooltip({
+  text,
+  className,
+  tooltipSide = "top",
+  tooltipClassName,
+}: TruncatedTextWithTooltipProps) {
+  const textRef = useRef<HTMLDivElement>(null);
+  const [isTruncated, setIsTruncated] = useState(false);
+
+  useEffect(() => {
+    const element = textRef.current;
+    if (!element) return;
+
+    // Check if text is truncated by comparing scrollWidth with clientWidth
+    const checkTruncation = () => {
+      setIsTruncated(element.scrollWidth > element.clientWidth);
+    };
+
+    checkTruncation();
+
+    // Re-check on window resize
+    window.addEventListener("resize", checkTruncation);
+    return () => window.removeEventListener("resize", checkTruncation);
+  }, [text]);
+
+  const content = (
+    <div ref={textRef} className={cn("truncate", className)}>
+      {text}
+    </div>
+  );
+
+  // Only wrap with Tooltip if text is truncated
+  if (!isTruncated) {
+    return content;
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <div className="cursor-help">{content}</div>
+      </TooltipTrigger>
+      <TooltipContent
+        side={tooltipSide}
+        className={cn("max-w-md break-words", tooltipClassName)}
+        sideOffset={5}
+      >
+        {text}
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/components/tracked-emails/columns/TrackedEmailsColumns.tsx
+++ b/components/tracked-emails/columns/TrackedEmailsColumns.tsx
@@ -8,13 +8,9 @@
 import { ColumnDef } from "@tanstack/react-table";
 import { AlertTriangleIcon, MailIcon } from "lucide-react";
 import { Checkbox } from "@/components/ui/checkbox";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
 import { TrackedEmailStatusBadge } from "../TrackedEmailStatusBadge";
 import { TrackedEmailActions } from "../TrackedEmailActions";
+import { TruncatedTextWithTooltip } from "../TruncatedTextWithTooltip";
 import { cn } from "@/lib/utils";
 import {
   formatDate,
@@ -78,35 +74,17 @@ export function createTrackedEmailsColumns(
         const subject = email.subject;
 
         return (
-          <div className="min-w-0">
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <div className="cursor-help truncate font-medium">
-                  {recipients}
-                </div>
-              </TooltipTrigger>
-              <TooltipContent
-                side="top"
-                className="max-w-md break-words"
-                sideOffset={5}
-              >
-                {recipients}
-              </TooltipContent>
-            </Tooltip>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <div className="text-muted-foreground cursor-help truncate text-sm">
-                  {subject}
-                </div>
-              </TooltipTrigger>
-              <TooltipContent
-                side="bottom"
-                className="max-w-md break-words"
-                sideOffset={5}
-              >
-                {subject}
-              </TooltipContent>
-            </Tooltip>
+          <div className="max-w-[250px] min-w-0">
+            <TruncatedTextWithTooltip
+              text={recipients}
+              className="font-medium"
+              tooltipSide="top"
+            />
+            <TruncatedTextWithTooltip
+              text={subject}
+              className="text-muted-foreground text-sm"
+              tooltipSide="bottom"
+            />
           </div>
         );
       },


### PR DESCRIPTION
## Résumé

Ajout de tooltips conditionnels qui ne s'affichent que lorsque le texte (destinataires ou sujet) est effectivement tronqué dans la colonne "Destinataire" du tableau des emails trackés.

## Changements

### Nouveau composant: `TruncatedTextWithTooltip`
- Détection automatique de la troncature via comparaison `scrollWidth > clientWidth`
- Tooltip n'apparaît **seulement** si le texte déborde
- Gestion responsive avec listener sur `resize`
- Configuration flexible (side, className)

### Modifications: `TrackedEmailsColumns.tsx`
- Ajout de `max-w-[250px]` pour forcer la troncature et éviter le scroll horizontal
- Remplacement des tooltips toujours affichés par le nouveau composant conditionnel
- Application sur les destinataires (top) et le sujet (bottom)

## Bénéfices

✅ **UX améliorée**: Tooltips uniquement quand nécessaire (pas de tooltip inutile sur texte court)
✅ **Performance**: Pas de scroll horizontal, largeur fixe de colonne
✅ **Responsive**: Recalcul automatique lors du redimensionnement
✅ **Réutilisable**: Composant générique utilisable ailleurs

## Test

- ✅ Texte court: pas de tooltip
- ✅ Texte long tronqué: tooltip s'affiche au survol avec contenu complet
- ✅ Redimensionnement: détection mise à jour
- ✅ Pas de scroll horizontal

🤖 Generated with [Claude Code](https://claude.com/claude-code)