### PR TITLE
feat: Amélioration du style et de la largeur des tooltips conditionnels

### DIFF
--- a/components/tracked-emails/TruncatedTextWithTooltip.tsx
+++ b/components/tracked-emails/TruncatedTextWithTooltip.tsx
@@ -64,12 +64,15 @@ export function TruncatedTextWithTooltip({
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <div className="cursor-help">{content}</div>
+        <div>{content}</div>
       </TooltipTrigger>
       <TooltipContent
         side={tooltipSide}
-        className={cn("max-w-md break-words", tooltipClassName)}
-        sideOffset={5}
+        className={cn(
+          "max-w-md bg-slate-900 px-4 py-2 text-sm break-words text-slate-50 shadow-lg",
+          tooltipClassName
+        )}
+        sideOffset={8}
       >
         {text}
       </TooltipContent>

--- a/components/tracked-emails/columns/TrackedEmailsColumns.tsx
+++ b/components/tracked-emails/columns/TrackedEmailsColumns.tsx
@@ -74,7 +74,7 @@ export function createTrackedEmailsColumns(
         const subject = email.subject;
 
         return (
-          <div className="max-w-[250px] min-w-0">
+          <div className="max-w-[300px] min-w-0">
             <TruncatedTextWithTooltip
               text={recipients}
               className="font-medium"
@@ -88,7 +88,7 @@ export function createTrackedEmailsColumns(
           </div>
         );
       },
-      size: 250,
+      size: 300,
       filterFn: multiColumnFilterFn,
       enableHiding: false,
     },


### PR DESCRIPTION
## Résumé

Amélioration du style des tooltips conditionnels et de la largeur de la colonne Destinataire :

- ✅ Augmentation de la largeur maximale de 250px à 300px pour la colonne Destinataire
- ✅ Amélioration du style du tooltip avec fond sombre et meilleur contraste
- ✅ Retrait du curseur d'aide (point d'interrogation) au survol
- ✅ Padding généreux et ombre portée pour meilleure lisibilité
- ✅ Espacement augmenté entre le texte et le tooltip

## Modifications techniques

### TruncatedTextWithTooltip.tsx
- Retrait de `cursor-help` sur le TooltipTrigger
- Ajout de classes Tailwind pour style amélioré : `bg-slate-900`, `text-slate-50`, `px-4`, `py-2`, `shadow-lg`
- Augmentation du `sideOffset` de 5 à 8

### TrackedEmailsColumns.tsx
- Changement de `max-w-[250px]` à `max-w-[300px]`
- Mise à jour de `size: 250` à `size: 300`

## Test plan

- [x] Vérifier que la colonne Destinataire a une largeur maximale de 300px
- [x] Vérifier que le tooltip s'affiche uniquement quand le texte est tronqué
- [x] Vérifier que le curseur reste normal au survol (pas de point d'interrogation)
- [x] Vérifier le style amélioré du tooltip (fond sombre, bon contraste)

🤖 Generated with [Claude Code](https://claude.com/claude-code)