### PR TITLE
feat: Support des pièces jointes dans les conversations

### DIFF
--- a/app/api/attachments/[messageId]/[attachmentId]/route.ts
+++ b/app/api/attachments/[messageId]/[attachmentId]/route.ts
@@ -1,0 +1,96 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { microsoftGraphService } from "@/lib/services/microsoft-graph.service";
+
+interface RouteParams {
+  params: Promise<{
+    messageId: string;
+    attachmentId: string;
+  }>;
+}
+
+/**
+ * GET /api/attachments/[messageId]/[attachmentId]
+ * Télécharge une pièce jointe d'un message
+ */
+export async function GET(request: NextRequest, context: RouteParams) {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { messageId, attachmentId } = await context.params;
+    const { searchParams } = new URL(request.url);
+    const mailboxId = searchParams.get("mailboxId");
+
+    if (!mailboxId) {
+      return NextResponse.json(
+        { error: "mailboxId is required" },
+        { status: 400 }
+      );
+    }
+
+    // Récupérer les informations de la mailbox
+    const { data: mailbox, error: mailboxError } = await supabase
+      .from("mailboxes")
+      .select("microsoft_user_id")
+      .eq("id", mailboxId)
+      .single();
+
+    if (mailboxError || !mailbox?.microsoft_user_id) {
+      return NextResponse.json(
+        { error: "Mailbox not found or not configured" },
+        { status: 404 }
+      );
+    }
+
+    // Récupérer la pièce jointe depuis Microsoft Graph
+    const attachment = await microsoftGraphService.getAttachment(
+      mailbox.microsoft_user_id,
+      messageId,
+      attachmentId
+    );
+
+    // Vérifier que c'est bien un FileAttachment
+    if (attachment["@odata.type"] !== "#microsoft.graph.fileAttachment") {
+      return NextResponse.json(
+        { error: "Only file attachments are supported for download" },
+        { status: 400 }
+      );
+    }
+
+    if (!attachment.contentBytes) {
+      return NextResponse.json(
+        { error: "Attachment content not available" },
+        { status: 404 }
+      );
+    }
+
+    // Décoder le contenu base64
+    const buffer = Buffer.from(attachment.contentBytes as string, "base64");
+
+    // Retourner le fichier avec les bons headers
+    return new NextResponse(buffer, {
+      headers: {
+        "Content-Type": attachment.contentType || "application/octet-stream",
+        "Content-Disposition": `attachment; filename="${attachment.name}"`,
+        "Content-Length": buffer.length.toString(),
+      },
+    });
+  } catch (error) {
+    console.error("[API] Error downloading attachment:", error);
+    return NextResponse.json(
+      {
+        error: "Failed to download attachment",
+        details: error instanceof Error ? error.message : "Unknown error",
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/components/tracked-emails/EmailConversationThread.tsx
+++ b/components/tracked-emails/EmailConversationThread.tsx
@@ -11,6 +11,8 @@ import {
   ArrowLeft,
   MailIcon,
   RefreshCwIcon,
+  FileIcon,
+  Download,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -63,6 +65,15 @@ const extractTextFromBody = (
 
   // Pour HTML, on affiche tel quel (le navigateur va le rendre)
   return body.content;
+};
+
+// Formater la taille des fichiers
+const formatFileSize = (bytes: number): string => {
+  if (bytes === 0) return "0 B";
+  const k = 1024;
+  const sizes = ["B", "KB", "MB", "GB"];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return `${Math.round((bytes / Math.pow(k, i)) * 10) / 10} ${sizes[i]}`;
 };
 
 export default function EmailConversationThread({
@@ -287,6 +298,35 @@ export default function EmailConversationThread({
                     </p>
                   )}
                 </div>
+
+                {/* Attachments */}
+                {message.attachments && message.attachments.length > 0 && (
+                  <div className="mt-2 space-y-1">
+                    {message.attachments
+                      .filter(att => !att.isInline)
+                      .map(attachment => (
+                        <a
+                          key={attachment.id}
+                          href={`/api/attachments/${message.id}/${attachment.id}?mailboxId=${mailboxId}`}
+                          download={attachment.name}
+                          className={`flex items-center gap-2 rounded-md px-3 py-2 text-xs transition-colors ${
+                            isSentMessage
+                              ? "bg-blue-600 text-white hover:bg-blue-700"
+                              : "bg-gray-200 text-gray-900 hover:bg-gray-300"
+                          }`}
+                        >
+                          <FileIcon className="h-4 w-4 flex-shrink-0" />
+                          <span className="flex-1 truncate font-medium">
+                            {attachment.name}
+                          </span>
+                          <span className="text-xs opacity-75">
+                            {formatFileSize(attachment.size)}
+                          </span>
+                          <Download className="h-3 w-3 flex-shrink-0" />
+                        </a>
+                      ))}
+                  </div>
+                )}
 
                 {/* Recipients (for sent messages) */}
                 {isSentMessage && message.toRecipients?.length > 0 && (

--- a/lib/types/microsoft-graph.ts
+++ b/lib/types/microsoft-graph.ts
@@ -140,13 +140,52 @@ export interface InternetMessageHeader {
   value: string;
 }
 
+// Types de pièces jointes Microsoft Graph
+export type AttachmentType =
+  | "#microsoft.graph.fileAttachment"
+  | "#microsoft.graph.itemAttachment"
+  | "#microsoft.graph.referenceAttachment";
+
 export interface EmailAttachment {
+  "@odata.type": AttachmentType;
   id: string;
   name: string;
   contentType: string;
   size: number;
   isInline: boolean;
   lastModifiedDateTime: string;
+}
+
+export interface FileAttachment extends EmailAttachment {
+  "@odata.type": "#microsoft.graph.fileAttachment";
+  contentBytes?: string; // Base64 encoded
+  contentId?: string;
+  contentLocation?: string;
+}
+
+export interface ItemAttachment extends EmailAttachment {
+  "@odata.type": "#microsoft.graph.itemAttachment";
+  item?: {
+    "@odata.type": string;
+    id: string;
+    subject?: string;
+  };
+}
+
+export interface ReferenceAttachment extends EmailAttachment {
+  "@odata.type": "#microsoft.graph.referenceAttachment";
+  sourceUrl?: string;
+  providerType?: string;
+  thumbnailUrl?: string;
+  previewUrl?: string;
+  permission?:
+    | "view"
+    | "edit"
+    | "anonymousView"
+    | "anonymousEdit"
+    | "organizationView"
+    | "organizationEdit";
+  isFolder?: boolean;
 }
 
 // ===== UTILISATEURS =====


### PR DESCRIPTION
## Résumé

Ajout du support complet des pièces jointes dans le fil de conversation avec Microsoft Graph API.

### Changements principaux

- 📎 **Types TypeScript** : 
  - `FileAttachment`, `ItemAttachment`, `ReferenceAttachment`
  - Support complet des métadonnées Microsoft Graph
  
- 🔄 **Intégration Microsoft Graph** :
  - `$expand=attachments` dans `getConversationThread()`
  - Nouvelle méthode `getAttachment()` pour récupérer le contenu

- 🌐 **API sécurisée** :
  - Route `/api/attachments/[messageId]/[attachmentId]`
  - Authentification via Supabase
  - Téléchargement avec headers appropriés
  - Support Base64 decode

- 🎨 **Interface utilisateur** :
  - Affichage des pièces jointes sous chaque message
  - Icône fichier + nom + taille formatée
  - Icône de téléchargement
  - Style adapté (bleu pour envoyés, gris pour reçus)
  - Filtrage des pièces jointes inline
  - Fonction `formatFileSize()` (B, KB, MB, GB)

### Détails techniques

**Nouveau fichier :**
- `app/api/attachments/[messageId]/[attachmentId]/route.ts`

**Fichiers modifiés :**
- `lib/types/microsoft-graph.ts` : Types des attachments
- `lib/services/microsoft-graph.service.ts` : Méthode `getAttachment()`
- `components/tracked-emails/EmailConversationThread.tsx` : UI des attachments

### Test

Lorsqu'un message contient des pièces jointes :
- [x] Les pièces jointes sont affichées sous le message
- [x] Clic sur une pièce jointe déclenche le téléchargement
- [x] La taille est formatée correctement
- [x] Le style s'adapte au type de message
- [x] Les pièces jointes inline sont filtrées

🤖 Generated with [Claude Code](https://claude.com/claude-code)