### PR TITLE
feat: Afficher les messages du plus récent au plus ancien

### DIFF
--- a/lib/services/microsoft-graph.service.ts
+++ b/lib/services/microsoft-graph.service.ts
@@ -512,12 +512,12 @@ export class MicrosoftGraphService {
         .top(100)
         .get();
 
-      // Tri côté serveur par sentDateTime (ascendant)
+      // Tri côté serveur par sentDateTime (descendant - du plus récent au plus ancien)
       const messages = (response.value as MicrosoftGraphEmailMessage[]) || [];
       messages.sort((a, b) => {
         const dateA = new Date(a.sentDateTime || a.receivedDateTime).getTime();
         const dateB = new Date(b.sentDateTime || b.receivedDateTime).getTime();
-        return dateA - dateB;
+        return dateB - dateA;
       });
 
       return messages;


### PR DESCRIPTION
## Résumé

Inverse l'ordre d'affichage des messages dans le thread de conversation pour afficher les messages les plus récents en premier.

## Changements

- ✅ Modifié le tri dans `getConversationThread()` de microsoft-graph.service.ts
- ✅ Changé de l'ordre ascendant (ancien → récent) à descendant (récent → ancien)
- ✅ Inversion de `dateA - dateB` en `dateB - dateA`

## Impact

Les utilisateurs verront maintenant les messages les plus récents en haut du thread, ce qui correspond à l'expérience utilisateur habituelle des applications de messagerie modernes.

## Test

✅ TypeScript strict check passé
✅ ESLint validation réussie
✅ Lint-staged formatage appliqué

🤖 Generated with [Claude Code](https://claude.com/claude-code)