### PR TITLE
fix: Afficher l'expéditeur et le sujet initiaux dans l'en-tête

### DIFF
--- a/components/tracked-emails/EmailConversationThread.tsx
+++ b/components/tracked-emails/EmailConversationThread.tsx
@@ -187,13 +187,13 @@ export default function EmailConversationThread({
     );
   }
 
-  // Extraire l'adresse de l'expéditeur et le sujet du premier message
-  const firstMessage = messages[0];
+  // Extraire l'adresse de l'expéditeur et le sujet du message initial (le plus ancien)
+  const initialMessage = messages[messages.length - 1];
   const senderEmail =
-    firstMessage?.sender?.emailAddress?.address ||
-    firstMessage?.from?.emailAddress?.address ||
+    initialMessage?.sender?.emailAddress?.address ||
+    initialMessage?.from?.emailAddress?.address ||
     "Expéditeur inconnu";
-  const subject = firstMessage?.subject || "Sans objet";
+  const subject = initialMessage?.subject || "Sans objet";
 
   return (
     <Card className="flex h-[calc(100vh-200px)] flex-col">
@@ -270,8 +270,8 @@ export default function EmailConversationThread({
                   )}
                 </div>
 
-                {/* Subject if different from first message */}
-                {index > 0 && message.subject !== messages[0]?.subject && (
+                {/* Subject if different from initial message */}
+                {message.subject !== initialMessage?.subject && (
                   <div className="text-sm font-medium text-gray-700">
                     {message.subject}
                   </div>


### PR DESCRIPTION
## Résumé

Corrige l'affichage de l'en-tête pour qu'il affiche toujours l'expéditeur initial et le sujet initial, même après l'inversion de l'ordre des messages.

## Problème

Avec le tri inversé (récent → ancien) introduit dans la PR #45, l'en-tête affichait l'expéditeur et le sujet du message le plus récent au lieu du message initial.

## Solution

- ✅ Utilise `messages[messages.length - 1]` (dernier élément = message initial) au lieu de `messages[0]`
- ✅ Renomme `firstMessage` en `initialMessage` pour plus de clarté
- ✅ Adapte la comparaison de sujet pour utiliser `initialMessage` au lieu de `messages[0]`

## Impact

L'en-tête affiche maintenant correctement :
- L'expéditeur qui a initié la conversation
- Le sujet original de la conversation

## Test

✅ TypeScript strict check passé
✅ ESLint validation réussie
✅ Lint-staged formatage appliqué

🤖 Generated with [Claude Code](https://claude.com/claude-code)