### PR TITLE
feat: Afficher les pièces jointes au-dessus du corps du message

### DIFF
--- a/components/tracked-emails/EmailConversationThread.tsx
+++ b/components/tracked-emails/EmailConversationThread.tsx
@@ -277,31 +277,9 @@ export default function EmailConversationThread({
                   </div>
                 )}
 
-                {/* Body */}
-                <div
-                  className={`rounded-lg px-4 py-3 ${
-                    isSentMessage
-                      ? "bg-blue-500 text-white"
-                      : "bg-gray-100 text-gray-900"
-                  }`}
-                >
-                  {message.body?.contentType === "html" ? (
-                    <div
-                      className="prose prose-sm max-w-none"
-                      dangerouslySetInnerHTML={{
-                        __html: message.body.content,
-                      }}
-                    />
-                  ) : (
-                    <p className="text-sm whitespace-pre-wrap">
-                      {extractTextFromBody(message.body) || message.bodyPreview}
-                    </p>
-                  )}
-                </div>
-
                 {/* Attachments */}
                 {message.attachments && message.attachments.length > 0 && (
-                  <div className="mt-2 space-y-1">
+                  <div className="mb-2 space-y-1">
                     {message.attachments
                       .filter(att => !att.isInline)
                       .map(attachment => (
@@ -327,6 +305,28 @@ export default function EmailConversationThread({
                       ))}
                   </div>
                 )}
+
+                {/* Body */}
+                <div
+                  className={`rounded-lg px-4 py-3 ${
+                    isSentMessage
+                      ? "bg-blue-500 text-white"
+                      : "bg-gray-100 text-gray-900"
+                  }`}
+                >
+                  {message.body?.contentType === "html" ? (
+                    <div
+                      className="prose prose-sm max-w-none"
+                      dangerouslySetInnerHTML={{
+                        __html: message.body.content,
+                      }}
+                    />
+                  ) : (
+                    <p className="text-sm whitespace-pre-wrap">
+                      {extractTextFromBody(message.body) || message.bodyPreview}
+                    </p>
+                  )}
+                </div>
 
                 {/* Recipients (for sent messages) */}
                 {isSentMessage && message.toRecipients?.length > 0 && (


### PR DESCRIPTION
## Résumé

Déplace les pièces jointes pour qu'elles s'affichent au-dessus du corps du message dans le thread de conversation.

## Changements

- ✅ Réorganise l'ordre d'affichage : Subject → Attachments → Body → Recipients
- ✅ Change la marge des pièces jointes de `mt-2` à `mb-2` pour un espacement correct
- ✅ Les pièces jointes sont maintenant plus visibles, affichées juste après le sujet

## Impact

Les utilisateurs voient immédiatement les pièces jointes avant de lire le corps du message, ce qui améliore la découvrabilité et l'accessibilité des fichiers joints.

## Test

✅ TypeScript strict check passé
✅ ESLint validation réussie
✅ Lint-staged formatage appliqué

🤖 Generated with [Claude Code](https://claude.com/claude-code)