### PR TITLE
feat: Remplacer la page de détails d'email par un Sheet

### DIFF
--- a/components/tracked-emails/EmailConversationThread.tsx
+++ b/components/tracked-emails/EmailConversationThread.tsx
@@ -21,6 +21,7 @@ interface EmailConversationThreadProps {
   trackedEmailId: string;
   mailboxId: string;
   mailboxEmail: string;
+  isInSheet?: boolean;
 }
 
 // Formater la date
@@ -80,6 +81,7 @@ export default function EmailConversationThread({
   trackedEmailId,
   mailboxId,
   mailboxEmail,
+  isInSheet = false,
 }: EmailConversationThreadProps) {
   const { messages, loading, error, refetch } = useEmailConversation(
     trackedEmailId,
@@ -92,11 +94,13 @@ export default function EmailConversationThread({
         <CardHeader>
           <div className="flex items-center justify-between">
             <CardTitle className="flex items-center gap-2 text-base">
-              <Button variant="ghost" size="sm" asChild>
-                <Link href="/dashboard" className="flex items-center gap-2">
-                  <ArrowLeft className="h-4 w-4" />
-                </Link>
-              </Button>
+              {!isInSheet && (
+                <Button variant="ghost" size="sm" asChild>
+                  <Link href="/dashboard" className="flex items-center gap-2">
+                    <ArrowLeft className="h-4 w-4" />
+                  </Link>
+                </Button>
+              )}
               <div className="flex flex-col gap-0.5">
                 <Skeleton className="h-4 w-48" />
                 <Skeleton className="h-3 w-32" />
@@ -125,11 +129,13 @@ export default function EmailConversationThread({
         <CardHeader>
           <div className="flex items-center justify-between">
             <CardTitle className="flex items-center gap-2 text-base">
-              <Button variant="ghost" size="sm" asChild>
-                <Link href="/dashboard" className="flex items-center gap-2">
-                  <ArrowLeft className="h-4 w-4" />
-                </Link>
-              </Button>
+              {!isInSheet && (
+                <Button variant="ghost" size="sm" asChild>
+                  <Link href="/dashboard" className="flex items-center gap-2">
+                    <ArrowLeft className="h-4 w-4" />
+                  </Link>
+                </Button>
+              )}
               <div className="flex items-center gap-2">
                 <AlertCircleIcon className="text-destructive h-4 w-4" />
                 <span className="text-sm">Erreur lors du chargement</span>
@@ -163,11 +169,13 @@ export default function EmailConversationThread({
         <CardHeader>
           <div className="flex items-center justify-between">
             <CardTitle className="flex items-center gap-2 text-base">
-              <Button variant="ghost" size="sm" asChild>
-                <Link href="/dashboard" className="flex items-center gap-2">
-                  <ArrowLeft className="h-4 w-4" />
-                </Link>
-              </Button>
+              {!isInSheet && (
+                <Button variant="ghost" size="sm" asChild>
+                  <Link href="/dashboard" className="flex items-center gap-2">
+                    <ArrowLeft className="h-4 w-4" />
+                  </Link>
+                </Button>
+              )}
               <div className="flex flex-col gap-0.5">
                 <span className="text-sm">Aucune conversation</span>
                 <span className="text-muted-foreground text-xs font-normal">
@@ -209,11 +217,13 @@ export default function EmailConversationThread({
       <CardHeader className="flex-none border-b">
         <div className="flex items-center justify-between">
           <CardTitle className="flex items-center gap-2 text-base">
-            <Button variant="ghost" size="sm" asChild>
-              <Link href="/dashboard" className="flex items-center gap-2">
-                <ArrowLeft className="h-4 w-4" />
-              </Link>
-            </Button>
+            {!isInSheet && (
+              <Button variant="ghost" size="sm" asChild>
+                <Link href="/dashboard" className="flex items-center gap-2">
+                  <ArrowLeft className="h-4 w-4" />
+                </Link>
+              </Button>
+            )}
             <div className="flex flex-col gap-0.5">
               <span className="text-sm">{contactEmail}</span>
               <span className="text-muted-foreground text-xs font-semibold">

--- a/components/tracked-emails/EmailDetailsSheet.tsx
+++ b/components/tracked-emails/EmailDetailsSheet.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { AlertCircleIcon } from "lucide-react";
+
+import { TrackedEmailService } from "@/lib/services/tracked-email.service";
+import type { TrackedEmailWithDetails } from "@/lib/types";
+
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+} from "@/components/ui/sheet";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Skeleton } from "@/components/ui/skeleton";
+import EmailConversationThread from "./EmailConversationThread";
+
+interface EmailDetailsSheetProps {
+  emailId: string | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export default function EmailDetailsSheet({
+  emailId,
+  open,
+  onOpenChange,
+}: EmailDetailsSheetProps) {
+  const [email, setEmail] = useState<TrackedEmailWithDetails | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!emailId || !open) {
+      return;
+    }
+
+    const fetchEmailDetails = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+
+        const emailData =
+          await TrackedEmailService.getTrackedEmailById(emailId);
+
+        if (!emailData) {
+          setError("Email non trouvé");
+          return;
+        }
+
+        setEmail(emailData);
+      } catch (err) {
+        setError(
+          err instanceof Error ? err.message : "Erreur lors du chargement"
+        );
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchEmailDetails();
+  }, [emailId, open]);
+
+  // Réinitialiser l'état quand le Sheet se ferme
+  useEffect(() => {
+    if (!open) {
+      setEmail(null);
+      setError(null);
+    }
+  }, [open]);
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="right" className="w-full sm:max-w-3xl">
+        {loading && (
+          <>
+            <SheetHeader>
+              <SheetTitle>Chargement...</SheetTitle>
+              <SheetDescription>
+                Récupération des détails de l&apos;email
+              </SheetDescription>
+            </SheetHeader>
+            <div className="space-y-4">
+              {[1, 2, 3].map(i => (
+                <div key={i} className="flex gap-3">
+                  <Skeleton className="h-10 w-10 rounded-full" />
+                  <div className="flex-1 space-y-2">
+                    <Skeleton className="h-4 w-32" />
+                    <Skeleton className="h-20 w-full" />
+                  </div>
+                </div>
+              ))}
+            </div>
+          </>
+        )}
+
+        {error && !loading && (
+          <>
+            <SheetHeader>
+              <SheetTitle>Erreur</SheetTitle>
+            </SheetHeader>
+            <Alert className="mt-6">
+              <AlertCircleIcon className="h-4 w-4" />
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          </>
+        )}
+
+        {email && !loading && !error && (
+          <>
+            <SheetHeader>
+              <SheetTitle className="text-base">
+                {email.recipient_emails}
+              </SheetTitle>
+              <SheetDescription className="text-sm">
+                {email.subject}
+              </SheetDescription>
+            </SheetHeader>
+            <div className="mt-6">
+              {email.mailbox ? (
+                <EmailConversationThread
+                  trackedEmailId={email.id}
+                  mailboxId={email.mailbox.id}
+                  mailboxEmail={email.mailbox.email_address}
+                  isInSheet={true}
+                />
+              ) : (
+                <Alert>
+                  <AlertCircleIcon className="h-4 w-4" />
+                  <AlertDescription>
+                    Informations de mailbox manquantes
+                  </AlertDescription>
+                </Alert>
+              )}
+            </div>
+          </>
+        )}
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/components/tracked-emails/TrackedEmailsTable.tsx
+++ b/components/tracked-emails/TrackedEmailsTable.tsx
@@ -12,7 +12,7 @@
 
 "use client";
 
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 import { ChevronDownIcon, ChevronUpIcon } from "lucide-react";
 import { flexRender } from "@tanstack/react-table";
 import {
@@ -34,8 +34,9 @@ import { useTrackedEmailsTable } from "./hooks/useTrackedEmailsTable";
 import { TrackedEmailsFilters } from "./filters/TrackedEmailsFilters";
 import { TrackedEmailsBulkActions } from "./bulk-actions/TrackedEmailsBulkActions";
 import { TrackedEmailsPagination } from "./pagination/TrackedEmailsPagination";
+import EmailDetailsSheet from "./EmailDetailsSheet";
 
-import type { EmailStatus } from "@/lib/types";
+import type { EmailStatus, TrackedEmailWithDetails } from "@/lib/types";
 
 /**
  * Main table component for tracked emails
@@ -43,6 +44,10 @@ import type { EmailStatus } from "@/lib/types";
  */
 export default function TrackedEmailsTable() {
   const { user } = useAuth();
+
+  // Sheet state
+  const [selectedEmailId, setSelectedEmailId] = useState<string | null>(null);
+  const [isSheetOpen, setIsSheetOpen] = useState(false);
 
   // Data management hook
   const { data, setData, loading } = useTrackedEmailsData();
@@ -55,11 +60,18 @@ export default function TrackedEmailsTable() {
     handleBulkDelete,
   } = useEmailActions({ user, setData });
 
+  // Handler for opening email details in sheet
+  const handleViewDetails = useCallback((email: TrackedEmailWithDetails) => {
+    setSelectedEmailId(email.id);
+    setIsSheetOpen(true);
+  }, []);
+
   // Table configuration hook
   const { table, statusColumn, uniqueStatusValues } = useTrackedEmailsTable({
     data,
     onStatusUpdate: handleStatusUpdate,
     onDelete: handleDeleteEmail,
+    onViewDetails: handleViewDetails,
   });
 
   // Status filter handler
@@ -185,6 +197,13 @@ export default function TrackedEmailsTable() {
 
       {/* Pagination */}
       <TrackedEmailsPagination table={table} />
+
+      {/* Email Details Sheet */}
+      <EmailDetailsSheet
+        emailId={selectedEmailId}
+        open={isSheetOpen}
+        onOpenChange={setIsSheetOpen}
+      />
     </div>
   );
 }

--- a/components/tracked-emails/hooks/useTrackedEmailsTable.ts
+++ b/components/tracked-emails/hooks/useTrackedEmailsTable.ts
@@ -6,7 +6,6 @@
  */
 
 import { useState, useMemo } from "react";
-import { useRouter } from "next/navigation";
 import {
   ColumnFiltersState,
   getCoreRowModel,
@@ -29,6 +28,7 @@ export interface UseTrackedEmailsTableOptions {
   data: TrackedEmailWithDetails[];
   onStatusUpdate: (emailId: string, status: EmailStatus) => Promise<void>;
   onDelete: (email: TrackedEmailWithDetails) => Promise<void>;
+  onViewDetails: (email: TrackedEmailWithDetails) => void;
 }
 
 /**
@@ -37,8 +37,7 @@ export interface UseTrackedEmailsTableOptions {
  * @returns Table instance and related state
  */
 export function useTrackedEmailsTable(options: UseTrackedEmailsTableOptions) {
-  const { data, onStatusUpdate, onDelete } = options;
-  const router = useRouter();
+  const { data, onStatusUpdate, onDelete, onViewDetails } = options;
 
   // Table state
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
@@ -58,9 +57,7 @@ export function useTrackedEmailsTable(options: UseTrackedEmailsTableOptions) {
   const columns = useMemo(() => {
     const columnOptions: CreateColumnsOptions = {
       onStatusUpdate,
-      onViewDetails: email => {
-        router.push(`/dashboard/emails/${email.id}`);
-      },
+      onViewDetails,
       onSendFollowup: email => {
         console.warn("Send followup:", email);
         // TODO: Implement followup modal
@@ -68,7 +65,7 @@ export function useTrackedEmailsTable(options: UseTrackedEmailsTableOptions) {
       onDelete,
     };
     return createTrackedEmailsColumns(columnOptions);
-  }, [router, onStatusUpdate, onDelete]);
+  }, [onStatusUpdate, onViewDetails, onDelete]);
 
   // Create table instance
   const table = useReactTable({

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import * as React from "react";
+import * as SheetPrimitive from "@radix-ui/react-dialog";
+import { XIcon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
+  return <SheetPrimitive.Root data-slot="sheet" {...props} />;
+}
+
+function SheetTrigger({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Trigger>) {
+  return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />;
+}
+
+function SheetClose({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Close>) {
+  return <SheetPrimitive.Close data-slot="sheet-close" {...props} />;
+}
+
+function SheetPortal({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Portal>) {
+  return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />;
+}
+
+function SheetOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Overlay>) {
+  return (
+    <SheetPrimitive.Overlay
+      data-slot="sheet-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function SheetContent({
+  className,
+  children,
+  side = "right",
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Content> & {
+  side?: "top" | "right" | "bottom" | "left";
+}) {
+  return (
+    <SheetPortal>
+      <SheetOverlay />
+      <SheetPrimitive.Content
+        data-slot="sheet-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+          side === "right" &&
+            "data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm",
+          side === "left" &&
+            "data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left inset-y-0 left-0 h-full w-3/4 border-r sm:max-w-sm",
+          side === "top" &&
+            "data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top inset-x-0 top-0 h-auto border-b",
+          side === "bottom" &&
+            "data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom inset-x-0 bottom-0 h-auto border-t",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        <SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
+          <XIcon className="size-4" />
+          <span className="sr-only">Close</span>
+        </SheetPrimitive.Close>
+      </SheetPrimitive.Content>
+    </SheetPortal>
+  );
+}
+
+function SheetHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-header"
+      className={cn("flex flex-col gap-1.5 p-4", className)}
+      {...props}
+    />
+  );
+}
+
+function SheetFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-footer"
+      className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+      {...props}
+    />
+  );
+}
+
+function SheetTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Title>) {
+  return (
+    <SheetPrimitive.Title
+      data-slot="sheet-title"
+      className={cn("text-foreground font-semibold", className)}
+      {...props}
+    />
+  );
+}
+
+function SheetDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Description>) {
+  return (
+    <SheetPrimitive.Description
+      data-slot="sheet-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Sheet,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetFooter,
+  SheetTitle,
+  SheetDescription,
+};


### PR DESCRIPTION
## Summary

Migre l'affichage des détails d'email d'une page dédiée vers un Sheet latéral pour améliorer l'expérience utilisateur avec une vue contextuelle.

## Changements

- ✨ Ajoute `EmailDetailsSheet.tsx` avec gestion du chargement et des erreurs
- 📦 Intègre le composant Sheet de shadcn/ui
- 🔧 Modifie `TrackedEmailsTable` pour ouvrir le Sheet au lieu de naviguer
- ⚙️ Adapte `useTrackedEmailsTable` pour utiliser un callback au lieu de router
- 🎨 Ajuste `EmailConversationThread` avec prop `isInSheet` pour masquer le bouton retour
- 🔗 Conserve la page `/dashboard/emails/[id]` pour les liens directs

## Avantages

- ⚡ Pas de rechargement de page
- 🚀 Navigation plus fluide
- 👁️ Vue contextuelle du tableau
- 📈 Meilleure performance

## Test plan

- [x] TypeScript strict check passe
- [x] ESLint vérifié
- [x] Hooks pre-commit exécutés
- [ ] Tester l'ouverture du Sheet depuis le tableau
- [ ] Vérifier que la page dédiée fonctionne toujours
- [ ] Valider l'accessibilité du Sheet

🤖 Generated with [Claude Code](https://claude.com/claude-code)