### PR TITLE
feat: Améliorer l'interface du Sheet de détails d'email

### DIFF
--- a/components/tracked-emails/EmailDetailsSheet.tsx
+++ b/components/tracked-emails/EmailDetailsSheet.tsx
@@ -109,33 +109,28 @@ export default function EmailDetailsSheet({
         )}
 
         {email && !loading && !error && (
-          <>
-            <SheetHeader>
-              <SheetTitle className="text-base">
-                {email.recipient_emails}
-              </SheetTitle>
-              <SheetDescription className="text-sm">
-                {email.subject}
-              </SheetDescription>
-            </SheetHeader>
-            <div className="mt-6">
-              {email.mailbox ? (
-                <EmailConversationThread
-                  trackedEmailId={email.id}
-                  mailboxId={email.mailbox.id}
-                  mailboxEmail={email.mailbox.email_address}
-                  isInSheet={true}
-                />
-              ) : (
-                <Alert>
+          <div className="flex h-full flex-col overflow-hidden">
+            {email.mailbox ? (
+              <EmailConversationThread
+                trackedEmailId={email.id}
+                mailboxId={email.mailbox.id}
+                mailboxEmail={email.mailbox.email_address}
+                isInSheet={true}
+              />
+            ) : (
+              <>
+                <SheetHeader>
+                  <SheetTitle>Erreur</SheetTitle>
+                </SheetHeader>
+                <Alert className="mt-6">
                   <AlertCircleIcon className="h-4 w-4" />
                   <AlertDescription>
                     Informations de mailbox manquantes
                   </AlertDescription>
                 </Alert>
-              )}
-            </div>
-          </>
+              </>
+            )}
+          </div>
         )}
       </SheetContent>
     </Sheet>


### PR DESCRIPTION
## Résumé

Amélioration complète de l'expérience utilisateur du composant Sheet pour l'affichage des détails d'email.

### Améliorations UI

- ✅ Suppression des en-têtes en double (SheetHeader + CardHeader)
- ✅ Gestion du défilement pour les conversations longues
- ✅ Passage de couleurs codées en dur aux variables de thème
- ✅ Suppression du composant Card dans le Sheet (conservé pour la page dédiée)
- ✅ Repositionnement du bouton d'actualisation (gauche au lieu de droite)
- ✅ Bordures fines à la place des couleurs de fond pour les messages
- ✅ Correction du débordement horizontal pour le contenu HTML/tables
- ✅ Affichage du sujet du message initial dans le fil
- ✅ Amélioration des paddings et responsive design

### Modifications techniques

- Split `EmailConversationThread` en deux rendus distincts (Sheet vs Page)
- Ajout de contraintes `min-w-0` et overflow pour responsive design
- Utilisation de variants Tailwind `[&_*]:max-w-full` pour HTML imbriqué
- Changement max-width des messages de 75% à 85%
- Amélioration de la structure flexbox pour l'overflow

### Fichiers modifiés

- `components/tracked-emails/EmailConversationThread.tsx`
- `components/tracked-emails/EmailDetailsSheet.tsx`
- `components/ui/sheet.tsx`

## Test plan

- [x] Ouvrir un email avec fil de discussion court → affichage correct
- [x] Ouvrir un email avec fil de discussion long → scroll fonctionne
- [x] Tester avec emails contenant des tables HTML → pas de débordement horizontal
- [x] Vérifier en mode clair et sombre → couleurs adaptées au thème
- [x] Vérifier le bouton d'actualisation → ne chevauche pas le bouton de fermeture
- [x] Vérifier l'affichage du sujet → visible pour le premier message

🤖 Generated with [Claude Code](https://claude.com/claude-code)