### PR TITLE
fix: révoquer EXECUTE sur fonctions SECURITY DEFINER exposées via RPC

### DIFF
--- a/supabase/migrations/20260506120018_revoke_execute_security_definer_functions.sql
+++ b/supabase/migrations/20260506120018_revoke_execute_security_definer_functions.sql
@@ -1,0 +1,81 @@
+-- Révoque EXECUTE sur les fonctions SECURITY DEFINER exposées via /rest/v1/rpc
+-- Corrige les avertissements `anon_security_definer_function_executable` et
+-- `authenticated_security_definer_function_executable` du linter Supabase.
+--
+-- IMPORTANT : Postgres accorde EXECUTE à PUBLIC par défaut sur les fonctions.
+-- anon et authenticated héritent de PUBLIC, donc il faut révoquer de PUBLIC
+-- (et de anon/authenticated explicitement par sécurité), puis GRANT sélectif.
+--
+-- Stratégie :
+--   1. Fonctions purement internes (triggers, cron, Edge Functions service_role,
+--      opérations admin) : tout révoquer. service_role conserve son GRANT existant.
+--   2. Helpers RLS appelés depuis les policies : révoquer puis re-GRANT à
+--      authenticated (les policies s'exécutent sous le rôle appelant).
+--   3. RPC destinées au frontend authentifié : révoquer puis GRANT à authenticated.
+--
+-- Idempotent : skip silencieux des fonctions absentes (drift local/remote).
+--
+-- Référence : https://supabase.com/docs/guides/database/database-linter?lint=0028_anon_security_definer_function_executable
+
+DO $$
+DECLARE
+  -- Fonctions internes : aucun rôle public, seul service_role conserve l'accès
+  internal_fns text[] := ARRAY[
+    -- Triggers
+    'public.handle_new_user()',
+    'public.handle_user_updated()',
+    'public.handle_user_deleted()',
+    'public.handle_email_conflict()',
+    'public.update_tracked_emails_fts()',
+    -- Cron-only (pg_cron tourne en superuser)
+    'public.get_cron_internal_key()',
+    'public.get_subscriptions_needing_renewal(integer)',
+    'public.get_email_cleanup_cron_status()',
+    'public.toggle_email_cleanup_cron(boolean)',
+    'public.trigger_email_cleanup()',
+    'public.cleanup_old_deleted_users(integer)',
+    -- Edge Functions (service_role)
+    'public.reschedule_pending_followups(uuid, timestamptz, integer)',
+    'public.get_total_followup_count(uuid)',
+    -- Sync / admin
+    'public.sync_user_to_auth()',
+    'public.sync_all_users_from_auth()',
+    'public.enable_user_sync()',
+    'public.disable_user_sync()',
+    'public.soft_delete_user(uuid)',
+    'public.hard_delete_user(uuid)',
+    'public.restore_user(uuid)'
+  ];
+  -- Fonctions accessibles à authenticated (helpers RLS + RPC frontend)
+  authenticated_fns text[] := ARRAY[
+    -- Helpers RLS (utilisés dans les policies)
+    'public.is_admin()',
+    'public.is_manager_or_admin()',
+    'public.current_user_role()',
+    'public.current_user_mailbox_ids()',
+    'public.can_access_followup(uuid)',
+    'public.is_user_deleted(uuid)',
+    -- RPC frontend
+    'public.archive_tracked_email(uuid, text)',
+    'public.search_tracked_emails(text)',
+    'public.get_dashboard_stats()'
+  ];
+  fn text;
+BEGIN
+  FOREACH fn IN ARRAY internal_fns LOOP
+    IF to_regprocedure(fn) IS NOT NULL THEN
+      EXECUTE format('REVOKE EXECUTE ON FUNCTION %s FROM PUBLIC, anon, authenticated', fn);
+    ELSE
+      RAISE NOTICE 'Skipping missing function: %', fn;
+    END IF;
+  END LOOP;
+
+  FOREACH fn IN ARRAY authenticated_fns LOOP
+    IF to_regprocedure(fn) IS NOT NULL THEN
+      EXECUTE format('REVOKE EXECUTE ON FUNCTION %s FROM PUBLIC, anon', fn);
+      EXECUTE format('GRANT EXECUTE ON FUNCTION %s TO authenticated', fn);
+    ELSE
+      RAISE NOTICE 'Skipping missing function: %', fn;
+    END IF;
+  END LOOP;
+END $$;

--- a/supabase/migrations/20260506173254_assert_security_definer_no_anon_execute.sql
+++ b/supabase/migrations/20260506173254_assert_security_definer_no_anon_execute.sql
@@ -1,0 +1,124 @@
+-- Suivi de 20260506120018_revoke_execute_security_definer_functions.sql
+--
+-- Renforce la posture de sécurité avec trois mécanismes :
+--   1. GRANT EXECUTE explicite à service_role sur les fonctions internes
+--      (defense in depth contre une éventuelle évolution des chaînes de
+--      privilèges par défaut de Supabase).
+--   2. Lock-down des helpers RLS test-only `is_service_role` et
+--      `get_bounce_mailbox_id` qui existent uniquement en environnement
+--      local (drift). Skip silencieux en production.
+--   3. Assertion de couverture : aucune fonction SECURITY DEFINER du schéma
+--      public ne doit rester exécutable par anon. Échoue la migration si
+--      l'invariant est violé → catch des renames silencieux et nouvelles
+--      fonctions oubliées par la migration précédente.
+--
+-- Section 4 (audit informatif) : log les fonctions encore accessibles à
+-- authenticated dans les logs de déploiement, pour faciliter les revues.
+
+-- ============================================================================
+-- 1. GRANT EXECUTE explicite à service_role sur les fonctions internes
+-- ============================================================================
+
+DO $$
+DECLARE
+  internal_fns text[] := ARRAY[
+    'public.handle_new_user()',
+    'public.handle_user_updated()',
+    'public.handle_user_deleted()',
+    'public.handle_email_conflict()',
+    'public.update_tracked_emails_fts()',
+    'public.get_cron_internal_key()',
+    'public.get_subscriptions_needing_renewal(integer)',
+    'public.get_email_cleanup_cron_status()',
+    'public.toggle_email_cleanup_cron(boolean)',
+    'public.trigger_email_cleanup()',
+    'public.cleanup_old_deleted_users(integer)',
+    'public.reschedule_pending_followups(uuid, timestamptz, integer)',
+    'public.get_total_followup_count(uuid)',
+    'public.sync_user_to_auth()',
+    'public.sync_all_users_from_auth()',
+    'public.enable_user_sync()',
+    'public.disable_user_sync()',
+    'public.soft_delete_user(uuid)',
+    'public.hard_delete_user(uuid)',
+    'public.restore_user(uuid)'
+  ];
+  fn text;
+BEGIN
+  FOREACH fn IN ARRAY internal_fns LOOP
+    IF to_regprocedure(fn) IS NOT NULL THEN
+      EXECUTE format('GRANT EXECUTE ON FUNCTION %s TO service_role', fn);
+    END IF;
+  END LOOP;
+END $$;
+
+-- ============================================================================
+-- 2. Lock-down des helpers RLS test-only (local uniquement, no-op en prod)
+-- ============================================================================
+
+DO $$
+DECLARE
+  test_helper_fns text[] := ARRAY[
+    'public.is_service_role()',
+    'public.get_bounce_mailbox_id(uuid)'
+  ];
+  fn text;
+BEGIN
+  FOREACH fn IN ARRAY test_helper_fns LOOP
+    IF to_regprocedure(fn) IS NOT NULL THEN
+      EXECUTE format('REVOKE EXECUTE ON FUNCTION %s FROM PUBLIC, anon', fn);
+      EXECUTE format('GRANT EXECUTE ON FUNCTION %s TO authenticated, service_role', fn);
+    END IF;
+  END LOOP;
+END $$;
+
+-- ============================================================================
+-- 3. Assertion de couverture (échec dur si l'invariant est violé)
+-- ============================================================================
+
+DO $$
+DECLARE
+  vulnerable_fns text[];
+BEGIN
+  SELECT array_agg(
+    p.proname || '(' || pg_get_function_identity_arguments(p.oid) || ')'
+    ORDER BY p.proname
+  )
+  INTO vulnerable_fns
+  FROM pg_proc p
+  JOIN pg_namespace n ON n.oid = p.pronamespace
+  WHERE n.nspname = 'public'
+    AND p.prosecdef = true
+    AND has_function_privilege('anon', p.oid, 'EXECUTE') = true;
+
+  IF vulnerable_fns IS NOT NULL AND array_length(vulnerable_fns, 1) > 0 THEN
+    RAISE EXCEPTION
+      'Sécurité : % fonction(s) SECURITY DEFINER de public restent exécutables par anon : %',
+      array_length(vulnerable_fns, 1), vulnerable_fns
+      USING HINT = 'Créer une migration avec REVOKE EXECUTE ... FROM PUBLIC, anon pour chaque fonction listée.';
+  END IF;
+END $$;
+
+-- ============================================================================
+-- 4. Audit informatif : fonctions exposées à authenticated
+-- ============================================================================
+
+DO $$
+DECLARE
+  authenticated_fns text[];
+  cnt integer;
+BEGIN
+  SELECT
+    array_agg(p.proname || '(' || pg_get_function_identity_arguments(p.oid) || ')' ORDER BY p.proname),
+    count(*)
+  INTO authenticated_fns, cnt
+  FROM pg_proc p
+  JOIN pg_namespace n ON n.oid = p.pronamespace
+  WHERE n.nspname = 'public'
+    AND p.prosecdef = true
+    AND has_function_privilege('authenticated', p.oid, 'EXECUTE') = true;
+
+  RAISE NOTICE
+    'Fonctions SECURITY DEFINER exposées à authenticated (% au total) : %',
+    cnt, COALESCE(authenticated_fns, ARRAY[]::text[]);
+END $$;


### PR DESCRIPTION
## Summary

Corrige les avertissements de sécurité Supabase (`anon_security_definer_function_executable` et `authenticated_security_definer_function_executable`) sur 29 fonctions du schéma `public`.

## Stratégie

- **Fonctions internes** (triggers, cron, sync admin, RPC Edge Functions) : `REVOKE FROM PUBLIC, anon, authenticated`. Seul `service_role` conserve l'accès → suffisant pour les Edge Functions et `pg_cron` (superuser).
- **Helpers RLS** (`is_admin`, `current_user_role`, `current_user_mailbox_ids`, `is_manager_or_admin`, `can_access_followup`, `is_user_deleted`) et **RPC frontend** (`archive_tracked_email`, `search_tracked_emails`, `get_dashboard_stats`) : `REVOKE FROM PUBLIC, anon` puis `GRANT TO authenticated`. Les policies s'exécutent sous le rôle appelant.

Migration idempotente : skippe silencieusement les fonctions absentes (drift local/remote possible).

## Test plan

- [x] `supabase db reset` applique sans erreur
- [x] `anon` bloqué : `permission denied for function is_admin`
- [x] `authenticated` bloqué sur fonctions internes : `permission denied for function handle_new_user`
- [x] `authenticated` autorisé sur helpers RLS : `is_admin()` retourne sans erreur de permission
- [x] `service_role` autorisé partout (les erreurs résiduelles sont des bugs pré-existants des fonctions, pas des permissions)
- [ ] Vérifier après `supabase db push` que `get_advisors` ne renvoie plus ces 58 lints

## Note manuelle

L'avertissement `auth_leaked_password_protection` doit être activé manuellement via le dashboard Supabase (Auth → Policies → "Leaked password protection") — non automatisable via migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Applied database migrations to tighten function execution permissions: removed anonymous/public execute access where appropriate and ensured only intended roles can run RPC-facing functions.
  * Added runtime assertions and audit checks to detect/expose any functions still executable by anonymous users, and made migrations safe to re-run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->